### PR TITLE
Modify http server bind address to bind to all interfaces

### DIFF
--- a/vfork/vfork/protocol/com/BullBoardBasicDist.java
+++ b/vfork/vfork/protocol/com/BullBoardBasicDist.java
@@ -182,7 +182,7 @@ public abstract class BullBoardBasicDist extends BullBoardBasic {
         if (!running) {
 
             log.info("Starting http server.");
-            httpServer = new SimpleHTTPServer(http_dir, httpl, backLog);
+            httpServer = new SimpleHTTPServer(http_dir, "0.0.0.0", httpl.getPort(), backLog);
             httpServer.start();
 
             running = true;


### PR DESCRIPTION
The Vfork http server always tries to bind on the public IP address, which will fail if the service is behind NAT or a reverse proxy. The PR proposes to make the server bind to any interface